### PR TITLE
Added `.cljc` to list of file types searched for.

### DIFF
--- a/src/marginalia/core.clj
+++ b/src/marginalia/core.clj
@@ -217,8 +217,8 @@
 
 (defn format-sources
   "Given a collection of filepaths, returns a lazy sequence of filepaths to all
-   files with valid file extensions on those paths: directory paths will be searched
-   recursively for files."
+   files with clojure source file extensions on those paths: directory paths
+   will be searched recursively for files."
   [sources]
   (if (nil? sources)
     (find-processable-file-paths "./src" file-extensions)

--- a/src/marginalia/core.clj
+++ b/src/marginalia/core.clj
@@ -213,11 +213,11 @@
 ;; These functions support Marginalia's use by client software or command-line
 ;; users.
 
-(def ^:private file-extensions #{"clj" "cljs" "cljx"})
+(def ^:private file-extensions #{"clj" "cljs" "cljx" "cljc"})
 
 (defn format-sources
   "Given a collection of filepaths, returns a lazy sequence of filepaths to all
-   .clj, .cljs, and .cljx files on those paths: directory paths will be searched
+   files with valid file extensions on those paths: directory paths will be searched
    recursively for files."
   [sources]
   (if (nil? sources)


### PR DESCRIPTION
As a result `lein marg` etc. now automatically compiles documentation for .cljc source files.
